### PR TITLE
Adding choose your own adventure pages for events

### DIFF
--- a/rpg/rpg.js
+++ b/rpg/rpg.js
@@ -193,7 +193,7 @@ function BioString(userID){
 }
 
 // Events
-function RunEvent(userID, channelID, goToPage=false){
+function RunEvent(userID, channelID, goToPage=0){
     if (!save.chars[userID].alive){
         var resChance = randomInt.Get(0, 100);
         if (resChance >= 95){
@@ -209,21 +209,18 @@ function RunEvent(userID, channelID, goToPage=false){
         }
         return;
     }
-    var ev = {"page":2};
-    if (goToPage == true){
-        var ev = genParts.events.filter(d => d.page === goToPage);
-        var ev = genParts.events.filter(function (pageID) {
-            return pageID.page === goToPage;
-        })[0];
-        console.log("Flipping to page", goToPage, ev.summary)
+    var index = randomInt.Get(0, genParts.events.length - 1);
+    var ev = genParts.events[index];
+    
+    if (goToPage){
+        ev = genParts.events.filter(event => event.page === goToPage)[0];
+        //console.log("Flipping to page", goToPage, ev.summary)
     }
-    else{
-        while (ev.page > 0){
-            var index = randomInt.Get(0, genParts.events.length - 1);
-            var ev = genParts.events[index];
-            var page = ev.page || false;
-        }
+    else if (ev.page){
+        RunEvent(userID, channelID);
+        return;
     }
+
     var summary = ev.summary;
     var item = {};
     var ally = "";
@@ -346,7 +343,7 @@ function HandleResult(userID, channelID, char, result, item, ally){
     delete save.events[userID];
     var outcomes = result[0].split(",");
     var message = result[1];
-    var goToPage = false;
+    var goToPage = 0;
     if (result.length == 3){
         goToPage = result[2];
     }

--- a/rpg/rpg.js
+++ b/rpg/rpg.js
@@ -193,7 +193,7 @@ function BioString(userID){
 }
 
 // Events
-function RunEvent(userID, channelID){
+function RunEvent(userID, channelID, goToPage=false){
     if (!save.chars[userID].alive){
         var resChance = randomInt.Get(0, 100);
         if (resChance >= 95){
@@ -209,9 +209,21 @@ function RunEvent(userID, channelID){
         }
         return;
     }
-    var index = randomInt.Get(0, genParts.events.length - 1);
-    var ev = genParts.events[index];
-
+    var ev = {"page":2};
+    if (goToPage == true){
+        var ev = genParts.events.filter(d => d.page === goToPage);
+        var ev = genParts.events.filter(function (pageID) {
+            return pageID.page === goToPage;
+        })[0];
+        console.log("Flipping to page", goToPage, ev.summary)
+    }
+    else{
+        while (ev.page > 0){
+            var index = randomInt.Get(0, genParts.events.length - 1);
+            var ev = genParts.events[index];
+            var page = ev.page || false;
+        }
+    }
     var summary = ev.summary;
     var item = {};
     var ally = "";
@@ -334,11 +346,14 @@ function HandleResult(userID, channelID, char, result, item, ally){
     delete save.events[userID];
     var outcomes = result[0].split(",");
     var message = result[1];
+    var goToPage = false;
+    if (result.length == 3){
+        goToPage = result[2];
+    }
     message = message.replace("<attack>", genParts.weapon[char.weapon.type]);
     if (ally && ally != "" && ally in save.chars){
         message = message.replace("<ally>", AllyDisplayName(ally));
     }
-
     for (var outcome of outcomes){
         if (outcome === "die"){
             char.alive = false;
@@ -430,6 +445,12 @@ function HandleResult(userID, channelID, char, result, item, ally){
     });
 
     SaveGame();
+
+    if(goToPage){
+        if (char.alive){
+            RunEvent(userID, channelID, goToPage);
+        }
+    }
 }
 
 function HandleAllyDeath(userID){

--- a/rpg/rpg_names.json
+++ b/rpg/rpg_names.json
@@ -1086,7 +1086,42 @@
           "fail": ["COOL -3", "Almost everyone else has joined in. You try to act cool, but you just look like a loner. This is just like fantasy highschool all over again."]
         }
       }
+  },
+  {
+      "summary": "You find a void puzzle cube. The cube is surrounded with eldritch energy, it doesn't so much tell you that it will never be solved, you just know.",
+      "setup": [],
+      "choices": {
+        "A": {
+          "action": "Try to solve the puzzle cube.",
+          "check": ["CON", 50],
+          "succeed": ["GOLD 400", "That wasn't so hard. You are rewarded for your persistence. The Elder Gods have taken note."],
+          "fail": ["GOLD -10,", "You are wasting your time and time is money. The cube takes its fee.", 1]
+        },
+        "B": {
+          "action": "Walk away.",
+          "check": [],
+          "succeed": ["", "You walk away from the challenge. A safe choice."]
+        }
+      }
+  },
+  {
+        "summary": "You face the impossible challenge once more. You are compelled to go on.",
+        "page": 1,
+        "setup": [],
+        "choices": {
+        "A": {
+          "action": "Try Again. You will not be defeated!",
+          "check": ["CON", 50],
+          "succeed": ["GOLD 400", "Impossible is nothing. You are rewarded for your persistence. The Elder Gods have taken note."],
+          "fail": ["GOLD -10,", "You are wasting your time and time is money. The cube takes its fee once more.", 1]
+        },
+        "B": {
+          "action": "Give up.",
+          "check": [],
+          "succeed": ["", "A wise choice. You leave the puzzle behind you. But will the puzzle ever leave you?"]
+        }
     }
+  }
   ]
 
 }


### PR DESCRIPTION
So i created an extra field to the outcome:
```
"fail": ["GOLD -10,", "You are wasting your time and time is money. The cube takes its fee.", 1]
```
Which is the equivalent to a choose your own adventure book's "go to page X" which then triggers the event with the page X field
```
{
    "summary": "You face the impossible challenge once more. You are compelled to go on.",
    "page": 1,
    ...
}
```
Made it so you can't start on an event that has a page number.
Made a recursive event, it does let you get into negative money, need to have multiple different parameter checks in the same action to fix that.
There’s no way of checking for page number overlap which is a bit annoying but ctrl-f works.
You can now chain events so they lead from one outcome to the next.